### PR TITLE
fix(B55): context sharing - inject tool diffs into conversation history

### DIFF
--- a/vibe/debate/agent.py
+++ b/vibe/debate/agent.py
@@ -507,3 +507,4 @@ class DebateAgent:
         """Clear conversation history but keep sessions alive."""
         self.messages.clear()
         self.last_seen = {"claude": -1, "gemini": -1}
+        self._action_contexts = []  # B55: Clear stale contexts


### PR DESCRIPTION
## Summary
- When one AI performs file operations (write/edit/shell), the other AI now receives the actual diff content in conversation context
- Previously Claude could not see what Gemini modified because only response text was stored in history
- Handles chained commands by accumulating action contexts

## Changes
- Added `_action_contexts` accumulator for chained commands
- Added `_build_action_context()` helper to format diffs
- Separated `ui_content` (display) from `history_content` (cross-AI context)

## Test
1. `@g create /tmp/test.py with print("hello")`
2. Approve
3. `@cc what did Gemini create?`
4. Claude now sees the diff in context

## Note
Claude parser has a separate bug (doesn't parse `╌` separator format) - will be fixed in follow-up PR.

## Summary by Sourcery

Improve cross-agent context sharing by including tool action diffs and outputs in conversation history while keeping UI display content separate.

Bug Fixes:
- Ensure one agent can see the other agent's file and shell changes by injecting formatted tool diffs into the shared conversation history.

Enhancements:
- Accumulate action contexts across chained tool commands and append them once to history to avoid losing intermediate diffs.
- Format tool actions (including capped diffs, shell output, and exit codes) into a concise, readable context block for history entries.
- Reset stored action contexts when clearing conversation history to prevent leaking stale context between sessions.