### PR TITLE
fix(B52+B59): Esc cancel + Tmux lifecycle management

### DIFF
--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -959,6 +959,10 @@ class VibeApp(App):
             except asyncio.CancelledError:
                 pass
 
+        # B52: Send Escape to tmux sessions before cancelling task
+        if self._debate_agent:
+            await self._debate_agent.interrupt()
+
         if self._agent_task and not self._agent_task.done():
             self._agent_task.cancel()
             try:

--- a/vibe/cli/textual_ui/app.py
+++ b/vibe/cli/textual_ui/app.py
@@ -76,7 +76,7 @@ class BottomApp(StrEnum):
     Input = auto()
 
 
-class VibeApp(App):
+class VibeApp(App):  # noqa: PLR0904
     ENABLE_COMMAND_PALETTE = False
     CSS_PATH = "app.tcss"
 
@@ -231,6 +231,15 @@ class VibeApp(App):
                 self._handle_user_message(self._initial_prompt), exclusive=False
             )
 
+    async def on_unmount(self) -> None:
+        """B59: Cleanup tmux sessions on app exit."""
+        if self._debate_agent:
+            try:
+                await self._debate_agent.__aexit__(None, None, None)
+            except Exception:
+                pass  # Best-effort cleanup
+            self._debate_agent = None
+
     async def on_chat_input_container_submitted(
         self, event: ChatInputContainer.Submitted
     ) -> None:
@@ -360,6 +369,15 @@ class VibeApp(App):
         if not backend:
             err = self._debate_agent._backend_errors.get(target, "unavailable")
             await self._mount_and_scroll(ErrorMessage(f"{target.capitalize()}: {err}"))
+            return
+
+        # B59: Backup check - session may have died after selector was shown
+        if not await backend.is_alive():
+            await self._mount_and_scroll(
+                ErrorMessage(
+                    f"{target.capitalize()} crashed. Restart TheOne to recover."
+                )
+            )
             return
 
         self._agent_running = True
@@ -721,7 +739,22 @@ class VibeApp(App):
                 except Exception:
                     pass
 
-                selector = TargetSelector(clean_msg)
+                # B59: Check which backends are alive before showing selector
+                disabled_targets: set[str] = set()
+                if self._debate_agent:
+                    if self._debate_agent._claude_backend:
+                        if not await self._debate_agent._claude_backend.is_alive():
+                            disabled_targets.add("claude")
+                    else:
+                        disabled_targets.add("claude")
+
+                    if self._debate_agent._gemini_backend:
+                        if not await self._debate_agent._gemini_backend.is_alive():
+                            disabled_targets.add("gemini")
+                    else:
+                        disabled_targets.add("gemini")
+
+                selector = TargetSelector(clean_msg, disabled_targets=disabled_targets)
                 # Mount above input, not in chat
                 bottom_container = self.query_one("#bottom-app-container")
                 await bottom_container.mount(selector, before=0)

--- a/vibe/cli_backends/claude/session.py
+++ b/vibe/cli_backends/claude/session.py
@@ -612,6 +612,10 @@ class ClaudeSessionTmux:
 
         return ParsedResponse(content="⚠️ Timeout")
 
+    def interrupt(self) -> None:
+        """Send Escape to stop generation (no-op if not generating)."""
+        subprocess.run(["tmux", "send-keys", "-t", self.session_name, "Escape"])
+
     def close(self) -> None:
         subprocess.run(["tmux", "send-keys", "-t", self.session_name, "/exit", "Enter"])
         time.sleep(1)

--- a/vibe/cli_backends/gemini/session.py
+++ b/vibe/cli_backends/gemini/session.py
@@ -380,6 +380,10 @@ class GeminiSessionTmux:
 
         return ParsedResponse(content="⚠️ Timeout")
 
+    def interrupt(self) -> None:
+        """Send Escape to stop generation (no-op if not generating)."""
+        subprocess.run(["tmux", "send-keys", "-t", self.session_name, "Escape"])
+
     def close(self) -> None:
         subprocess.run(["tmux", "send-keys", "-t", self.session_name, "/exit", "Enter"])
         time.sleep(1)

--- a/vibe/cli_backends/gemini/session.py
+++ b/vibe/cli_backends/gemini/session.py
@@ -16,10 +16,12 @@ class GeminiSessionTmux:
         self.session_name = session_name
         self._parser = GeminiToolParser()
 
-    def _capture_pane(self, lines: int = 500) -> str:
-        """Capture tmux pane content (plain text, no ANSI)."""
+    def _capture_pane(self, lines: int = 500) -> str | None:
+        """Capture tmux pane content. Returns None if session dead (B59)."""
         cmd = ["tmux", "capture-pane", "-t", self.session_name, "-p", "-S", f"-{lines}"]
         result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            return None
         return result.stdout
 
     def start(self) -> None:
@@ -71,6 +73,9 @@ class GeminiSessionTmux:
                 return "❌ Tmux session dead. Click Restart."
 
             before = self._capture_pane()
+            # B59: Detect dead session (unlikely after has-session check, but safe)
+            if before is None:
+                return "❌ Gemini crashed. Restart TheOne to recover."
             responses_before = before.count("✦") + before.count("✧")
 
             # B49 fix: load-buffer + paste-buffer with -p (bracketed paste) and -r (preserve newlines)
@@ -96,6 +101,9 @@ class GeminiSessionTmux:
                 # TODO B44/B53: Measure polling performance (capture + parse)
                 t_poll_start = time.time()
                 output = self._capture_pane()
+                # B59: Detect dead session during polling
+                if output is None:
+                    return "❌ Gemini crashed. Restart TheOne to recover."
                 t_capture = time.time()
 
                 if on_update:
@@ -137,6 +145,9 @@ class GeminiSessionTmux:
                     ):
                         time.sleep(1)
                         output = self._capture_pane()
+                        # B59: Detect dead session
+                        if output is None:
+                            return "❌ Gemini crashed. Restart TheOne to recover."
                         return self._extract_response(output, responses_before)
 
             return "⚠️ Timeout"
@@ -320,11 +331,21 @@ class GeminiSessionTmux:
         last_output = ""  # B44/B53: Cache to skip parse if buffer unchanged
 
         before = self._capture_pane()
+        # B59: Detect dead session
+        if before is None:
+            return ParsedResponse(
+                content="❌ Gemini crashed. Restart TheOne to recover."
+            )
         responses_before = before.count("✦") + before.count("✧")
 
         while time.time() - start_time < timeout:
             time.sleep(1)
             output = self._capture_pane()
+            # B59: Detect dead session during polling
+            if output is None:
+                return ParsedResponse(
+                    content="❌ Gemini crashed. Restart TheOne to recover."
+                )
 
             if on_update:
                 # B44/B53 fix: Skip parse if buffer unchanged (AI thinking, no new content)
@@ -383,6 +404,13 @@ class GeminiSessionTmux:
     def interrupt(self) -> None:
         """Send Escape to stop generation (no-op if not generating)."""
         subprocess.run(["tmux", "send-keys", "-t", self.session_name, "Escape"])
+
+    def is_alive(self) -> bool:
+        """B59: Check if tmux session is still running."""
+        result = subprocess.run(
+            ["tmux", "has-session", "-t", self.session_name], capture_output=True
+        )
+        return result.returncode == 0
 
     def close(self) -> None:
         subprocess.run(["tmux", "send-keys", "-t", self.session_name, "/exit", "Enter"])

--- a/vibe/core/llm/backend/tmux.py
+++ b/vibe/core/llm/backend/tmux.py
@@ -199,6 +199,12 @@ class TmuxBackend:
                 total += len(msg.content)
         return total // 4
 
+    async def is_alive(self) -> bool:
+        """B59: Check if tmux session is still running."""
+        if self._session is None:
+            return False
+        return await asyncio.to_thread(self._session.is_alive)
+
     async def close(self) -> None:
         """Close the session."""
         if self._session is not None:

--- a/vibe/core/llm/backend/tmux.py
+++ b/vibe/core/llm/backend/tmux.py
@@ -67,6 +67,11 @@ class TmuxBackend:
             await asyncio.to_thread(self._session.close)
             self._session = None
 
+    async def interrupt(self) -> None:
+        """Interrupt current generation (no-op if not generating)."""
+        if self._session:
+            await asyncio.to_thread(self._session.interrupt)
+
     def _messages_to_prompt(self, messages: list[LLMMessage]) -> str:
         """Convert LLMMessage list to single prompt string."""
         if not messages:

--- a/vibe/debate/agent.py
+++ b/vibe/debate/agent.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
 from datetime import datetime
 import logging
 import re
+import subprocess
 import types
 from typing import TYPE_CHECKING
 
@@ -64,9 +66,32 @@ class DebateAgent:
         self._gemini_parser = GeminiToolParser()
         self._claude_parser = ClaudeToolParser()
 
+    async def _cleanup_orphan_sessions(self) -> None:
+        """B59: Kill orphan tmux sessions from previous crashes."""
+
+        def _cleanup() -> None:
+            result = subprocess.run(
+                ["tmux", "list-sessions", "-F", "#{session_name}"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                for session in result.stdout.strip().split("\n"):
+                    if session and (
+                        session.startswith("claude_") or session.startswith("gemini_")
+                    ):
+                        subprocess.run(
+                            ["tmux", "kill-session", "-t", session], capture_output=True
+                        )
+
+        await asyncio.to_thread(_cleanup)
+
     async def __aenter__(self) -> DebateAgent:
         """Start both tmux sessions. Continue if one fails (F8)."""
         self._backend_errors: dict[str, str] = {}
+
+        # B59: Cleanup orphan sessions from previous crashes (once, before starting)
+        await self._cleanup_orphan_sessions()
 
         # Claude
         try:

--- a/vibe/debate/agent.py
+++ b/vibe/debate/agent.py
@@ -481,6 +481,13 @@ class DebateAgent:
 
         return "\n".join(lines)
 
+    async def interrupt(self) -> None:
+        """Interrupt all backends (safe, idempotent)."""
+        if self._claude_backend:
+            await self._claude_backend.interrupt()
+        if self._gemini_backend:
+            await self._gemini_backend.interrupt()
+
     def clear_history(self) -> None:
         """Clear conversation history but keep sessions alive."""
         self.messages.clear()


### PR DESCRIPTION
## Summary
- **B52**: Esc now cancels ongoing AI generation in tmux sessions
- **B59**: Tmux sessions are properly managed throughout app lifecycle

## Why
- B52: Users had no way to stop a long AI response mid-generation
- B59: Orphan tmux sessions accumulated after crashes, dead sessions caused silent freezes, no feedback when backend died

## What
- B52: Esc sends interrupt to tmux, cancels generation
- B59: 
  - Orphan cleanup at startup
  - Health checks detect dead sessions during polling (no more 120s timeout)
  - Dead backends show error + buttons grayed out
  - Clean exit kills tmux sessions

## Summary by Sourcery

Handle tmux-backed AI sessions more robustly and allow users to cancel generations via Escape.

New Features:
- Add Escape-based interrupt support to tmux-backed Claude and Gemini sessions, exposing interrupt methods through the DebateAgent and TmuxBackend.
- Disable crashed or unavailable AI backends in the target selector UI and prevent selection of dead targets.

Bug Fixes:
- Detect dead tmux sessions for Claude and Gemini during startup and polling, returning clear crash messages instead of hanging or timing out.
- Ensure app unmount cleans up tmux sessions to avoid orphaned sessions after exits or crashes.

Enhancements:
- Add health checks for tmux-backed backends and surface crashes in the UI before routing messages.
- Introduce startup-time cleanup of orphan Claude and Gemini tmux sessions created by previous runs.